### PR TITLE
fix: send Slack issue notifications through bot

### DIFF
--- a/.github/workflows/slack-issue-notifications.yml
+++ b/.github/workflows/slack-issue-notifications.yml
@@ -19,13 +19,10 @@ jobs:
       - name: Send notification to Slack
         uses: actions/github-script@v8
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
         with:
           script: |
-            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
-
             const { issue, repository, sender } = context.payload;
             const isClosed = context.eventName === "issues" && context.payload.action === "closed";
             const isComment = context.eventName === "issue_comment";
@@ -41,6 +38,11 @@ jobs:
             const commentBody = isComment
               ? escapeSlack(context.payload.comment?.body?.trim()).slice(0, 700)
               : "";
+
+            if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_CHANNEL_ID) {
+              core.setFailed("Missing repository secrets: SLACK_BOT_TOKEN and SLACK_CHANNEL_ID");
+              return;
+            }
 
             async function slackApi(method, body) {
               const response = await fetch(`https://slack.com/api/${method}`, {
@@ -59,11 +61,6 @@ jobs:
             }
 
             if (isClosed) {
-              if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_CHANNEL_ID) {
-                core.setFailed("Missing repository secrets: SLACK_BOT_TOKEN and SLACK_CHANNEL_ID");
-                return;
-              }
-
               let cursor;
               let threadTs;
               do {
@@ -94,17 +91,7 @@ jobs:
               ? `*New Comment:* <${issueUrl}|${escapeSlack(issue.title)}>\n\n*${escapeSlack(actor)}* in <${repositoryUrl}|${escapeSlack(repository.full_name)}>\n\n${commentBody}`
               : `*New Issue:* <${issueUrl}|${escapeSlack(issue.title)}>\n\n*${escapeSlack(actor)}* in <${repositoryUrl}|${escapeSlack(repository.full_name)}>`;
 
-            if (!webhookUrl) {
-              core.setFailed("Missing repository secret: SLACK_WEBHOOK_URL");
-              return;
-            }
-
-            const response = await fetch(webhookUrl, {
-              method: "POST",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({ text: message }),
+            await slackApi("chat.postMessage", {
+              channel: process.env.SLACK_CHANNEL_ID,
+              text: message,
             });
-
-            if (!response.ok) {
-              throw new Error(`Slack webhook failed: ${response.status} ${await response.text()}`);
-            }


### PR DESCRIPTION
Replace Incoming Webhook delivery with Slack Web API chat.postMessage for new issues and comments.

All notifications now use the same bot identity and existing SLACK_BOT_TOKEN / SLACK_CHANNEL_ID secrets.